### PR TITLE
Edited pom.xml via GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>me.prettyprint</groupId>
 			<artifactId>hector-core</artifactId>
-			<version>0.8.0-2-SNAPSHOT</version>
+			<version>0.8.0-2</version>
 			
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Nate, the POM referenced the SNAPSHOT of Hector. Peeps be getting mad crazy errors....

```
[ERROR] Failed to execute goal on project cassandra-tutorial: Could not resolve dependencies for project com.datastax.tutorial:cassandra-tutorial:jar:1.0-SNAPSHOT: Could not find artifact me.prettyprint:hector-core:jar:0.8.0-2-SNAPSHOT -> [Help 1]
```
